### PR TITLE
Fix start script overwriting config

### DIFF
--- a/setup/start.sh
+++ b/setup/start.sh
@@ -5,15 +5,18 @@ ln -s /dev/stdout /var/log/php7/error.log
 ln -s /dev/stdout /var/log/nginx/access.log
 ln -s /dev/stdout /var/log/nginx/error.log
 
-sed \
-  -e "s/DB_HOSTNAME=/DB_HOSTNAME=${MYSQL_HOST}/" \
-  -e "s/DB_USERNAME=/DB_USERNAME=${MYSQL_USER}/" \
-  -e "s/DB_PASSWORD=/DB_PASSWORD=${MYSQL_PASSWORD}/" \
-  -e "s/DB_DATABASE=/DB_DATABASE=${MYSQL_DB}/" \
-  -e "s/DB_PORT=/DB_PORT=${MYSQL_PORT}/" \
-  -e "s!IP_URL=!IP_URL=${IP_URL}!" \
-  -e "s/DISABLE_SETUP=false/DISABLE_SETUP=${DISABLE_SETUP}/" \
-/var/www/html/ipconfig.php.example > /var/www/html/ipconfig.php;
+if [ ! -f "/var/www/html/ipconfig.php" ]; then
+  sed \
+    -e "s/DB_HOSTNAME=/DB_HOSTNAME=${MYSQL_HOST}/" \
+    -e "s/DB_USERNAME=/DB_USERNAME=${MYSQL_USER}/" \
+    -e "s/DB_PASSWORD=/DB_PASSWORD=${MYSQL_PASSWORD}/" \
+    -e "s/DB_DATABASE=/DB_DATABASE=${MYSQL_DB}/" \
+    -e "s/DB_PORT=/DB_PORT=${MYSQL_PORT}/" \
+    -e "s!IP_URL=!IP_URL=${IP_URL}!" \
+    -e "s/DISABLE_SETUP=false/DISABLE_SETUP=${DISABLE_SETUP}/" \
+  /var/www/html/ipconfig.php.example > /var/www/html/ipconfig.php;
+fi
+
 chown nobody:nginx /var/www/html/ipconfig.php;
 
 php-fpm7


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Issue: https://github.com/mhzawadi/invoiceplane/issues/2

When restarting a container that has already been setup (i.e. the `ipconfig.php` has `SETUP_COMPLETED=true`) with a persistent config file attached (e.g. `-v /path/to/ipconfig.php:/var/www/html/ipconfig.php`), the config file is overwritten with a new one from `/var/www/html/ipconfig.php.example` by the `start.sh` script.

* **What is the new behavior (if this is a feature change)?**

The `start.sh` script now checks that there is no existing `/var/www/html/ipconfig.php` file before overwriting with the `/var/www/html/ipconfig.php.example` file.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Shouldn't introduce any breaking changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mhzawadi/invoiceplane/4)
<!-- Reviewable:end -->
